### PR TITLE
🎉 Release 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@psych0d0g, @Cronix, @Lukas Wingerberg
+@Lukas Wingerberg, @psych0d0g, @Cronix
 
 ### Misc
 
+- move arg ([39ff3a6](https://github.com/CrystalNET-org/paperless-ftpd/commit/39ff3a6dea68b4e1754f8ed13e6ea6e318aabe53))
+- Update renovate/renovate Docker tag to v38 [[#13](https://github.com/CrystalNET-org/paperless-ftpd/pull/13)]
 - Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#12](https://github.com/CrystalNET-org/paperless-ftpd/pull/12)]
 - Update renovate/renovate Docker tag to v37.440.7 [[#11](https://github.com/CrystalNET-org/paperless-ftpd/pull/11)]
 - comment default ([5b2524c](https://github.com/CrystalNET-org/paperless-ftpd/commit/5b2524c2e4b96bd88c126478d3037e0553bcce0e))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Lukas Wingerberg, @Cronix, @psych0d0g
+@psych0d0g, @Cronix, @Lukas Wingerberg
 
 ### Misc
 
+- Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#12](https://github.com/CrystalNET-org/paperless-ftpd/pull/12)]
+- Update renovate/renovate Docker tag to v37.440.7 [[#11](https://github.com/CrystalNET-org/paperless-ftpd/pull/11)]
+- comment default ([5b2524c](https://github.com/CrystalNET-org/paperless-ftpd/commit/5b2524c2e4b96bd88c126478d3037e0553bcce0e))
 - update dependencies and fix paperless-auth release location ([c2ce914](https://github.com/CrystalNET-org/paperless-ftpd/commit/c2ce9146c01b9d468e34c03cdd2d346592456f2e))
 - update paperless-dbauth plugin to latest version ([a41b6b2](https://github.com/CrystalNET-org/paperless-ftpd/commit/a41b6b2569b91256430b15667946b476e2ba9532))
 - Update renovate/renovate Docker tag to v37.140.10 [[#8](https://github.com/CrystalNET-org/paperless-ftpd/pull/8)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
-## [0.2.4](https://github.com/CrystalNET-org/paperless-ftpd/releases/tag/0.2.4) - 2024-02-05
+## [0.2.4](https://github.com/CrystalNET-org/paperless-ftpd/releases/tag/0.2.4) - 2024-10-28
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@psych0d0g
+@Lukas Wingerberg, @Cronix, @psych0d0g
 
 ### Misc
 
+- update dependencies and fix paperless-auth release location ([c2ce914](https://github.com/CrystalNET-org/paperless-ftpd/commit/c2ce9146c01b9d468e34c03cdd2d346592456f2e))
+- update paperless-dbauth plugin to latest version ([a41b6b2](https://github.com/CrystalNET-org/paperless-ftpd/commit/a41b6b2569b91256430b15667946b476e2ba9532))
 - Update renovate/renovate Docker tag to v37.140.10 [[#8](https://github.com/CrystalNET-org/paperless-ftpd/pull/8)]
 - Update renovate/renovate Docker tag to v37.115.0 [[#7](https://github.com/CrystalNET-org/paperless-ftpd/pull/7)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+## [0.2.3](https://github.com/CrystalNET-org/paperless-ftpd/releases/tag/0.2.3) - 2023-12-22
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Psych0D0g, @psych0d0g
+
+### Misc
+
+- add release-helper pipeline ([dde6206](https://github.com/CrystalNET-org/paperless-ftpd/commit/dde62066f6f060ac0978622dbdb5f35a34e9b1e7))
+- add release-helper pipeline ([d1804d4](https://github.com/CrystalNET-org/paperless-ftpd/commit/d1804d48737a05cd0989bd52555fe1a50304ec74))
+- remove context ([083a0cb](https://github.com/CrystalNET-org/paperless-ftpd/commit/083a0cb221c74663041f5727ea67b81a6369233c))
+- test ([8dbcabf](https://github.com/CrystalNET-org/paperless-ftpd/commit/8dbcabf478f3203a86553dc5667aa4a67fe49b6e))
+- test ([5a9149f](https://github.com/CrystalNET-org/paperless-ftpd/commit/5a9149f6e49f90dc14e9305ff49899a1694225c2))
+- test ([14d85df](https://github.com/CrystalNET-org/paperless-ftpd/commit/14d85df89cf21bde54fa223e0b047a1ed7667d93))
+- cleanup ([84885a9](https://github.com/CrystalNET-org/paperless-ftpd/commit/84885a9d6a8f961ad2b90366ec55e9ad720440b3))
+- refactor to only be a single container repo ([c957c19](https://github.com/CrystalNET-org/paperless-ftpd/commit/c957c19701e41c2b873afd5fe5fe210f05ec8379))
+- refine pipelines for future containers ([18dc1aa](https://github.com/CrystalNET-org/paperless-ftpd/commit/18dc1aae870e296980a56ef06500412eef171035))
+- limit build-step to container paperless-ftpd ([adb136f](https://github.com/CrystalNET-org/paperless-ftpd/commit/adb136ffb3b60147c1b1ef11b4e31dcdaae68348))
+- rename container to paperless-ftpd ([f11b88d](https://github.com/CrystalNET-org/paperless-ftpd/commit/f11b88df3d66ded9ab13d90651849cf4182efd27))
+- rename container to paperless-ftpd ([d9f42c5](https://github.com/CrystalNET-org/paperless-ftpd/commit/d9f42c5d07d6c1ef9a31f8966d3d2ad4b4c26777))
+- update renovate config ([7f5011c](https://github.com/CrystalNET-org/paperless-ftpd/commit/7f5011c82ab5edd60ab79239158ab172a6b779c3))
+- update renovate config ([ac25ee7](https://github.com/CrystalNET-org/paperless-ftpd/commit/ac25ee7dc55f63f0720388bf81e645cd8a449f67))
+- update renovate config ([2c48602](https://github.com/CrystalNET-org/paperless-ftpd/commit/2c48602e4bd9e7ce95e9b11c52176fa0bdfd44e3))
+- update renovate config ([82f6627](https://github.com/CrystalNET-org/paperless-ftpd/commit/82f66274bc08ab794f9f6041e92ec1231030465a))
+- update renovate config ([5d82993](https://github.com/CrystalNET-org/paperless-ftpd/commit/5d82993923044f40138f23d46b1a745fc5be281e))
+- Update woodpeckerci/plugin-docker-buildx Docker tag to v2.2.1 [[#5](https://github.com/CrystalNET-org/paperless-ftpd/pull/5)]
+- Update renovate/renovate Docker tag to v37 [[#4](https://github.com/CrystalNET-org/paperless-ftpd/pull/4)]
+- Update renovate/renovate Docker tag to v37 [[#4](https://github.com/CrystalNET-org/paperless-ftpd/pull/4)]
+- Update woodpeckerci/plugin-docker-buildx Docker tag to v2.2.1 [[#5](https://github.com/CrystalNET-org/paperless-ftpd/pull/5)]
+- update renovate config ([74c1d4b](https://github.com/CrystalNET-org/paperless-ftpd/commit/74c1d4b222a77cb4c92c96e427420702b23b578d))
+- update renovate config ([09b6f5b](https://github.com/CrystalNET-org/paperless-ftpd/commit/09b6f5b186a91374bf5a049a60198c80c193d0bd))
+- Update renovate/renovate Docker tag to v35.159.7 [[#3](https://github.com/CrystalNET-org/paperless-ftpd/pull/3)]
+- update renovate config ([34ceb7f](https://github.com/CrystalNET-org/paperless-ftpd/commit/34ceb7f49d7438f033734fdf9e0e298ae8805ecd))
+- Update renovate/renovate Docker tag to v35.159.7 [[#3](https://github.com/CrystalNET-org/paperless-ftpd/pull/3)]
+- update renovate config ([9f7fa16](https://github.com/CrystalNET-org/paperless-ftpd/commit/9f7fa1640ddd62632a1d6b3b23e8fc3e34edb69c))
+- update renovate config ([d9f335e](https://github.com/CrystalNET-org/paperless-ftpd/commit/d9f335e8a752af1e6beb664338547f26fe3e4e6b))
+- update renovate config ([aa1c4f0](https://github.com/CrystalNET-org/paperless-ftpd/commit/aa1c4f0bdb281fb04922f005445cd66181be08f4))
+- update renovate config ([ded321d](https://github.com/CrystalNET-org/paperless-ftpd/commit/ded321d236da1ba61d28352986456b027719c288))
+- update renovate config ([2620490](https://github.com/CrystalNET-org/paperless-ftpd/commit/26204906052bf144602aeab57fbe1dcc70b3e94c))
+- update renovate config ([cd29d52](https://github.com/CrystalNET-org/paperless-ftpd/commit/cd29d52501f7be35d72f483a9343902edc1feab0))
+- update renovate config ([f50e221](https://github.com/CrystalNET-org/paperless-ftpd/commit/f50e2219a5d43aa66b37c372b72a21cd77897b3c))
+- update renovate config ([7063371](https://github.com/CrystalNET-org/paperless-ftpd/commit/706337152e14eec792e8e8bbbfe9e3696e7990ef))
+- update renovate config ([aa67527](https://github.com/CrystalNET-org/paperless-ftpd/commit/aa675274a979698684b8054aefeaf69073ac0456))
+- update renovate config ([d2309fc](https://github.com/CrystalNET-org/paperless-ftpd/commit/d2309fcc20c919a8930afbaa740fb8a21e89dcb7))
+- update renovate config ([04cd5b5](https://github.com/CrystalNET-org/paperless-ftpd/commit/04cd5b5dc9895fefbd23ead63f8fcc9c06a5cd66))
+- Configure Renovate [[#1](https://github.com/CrystalNET-org/paperless-ftpd/pull/1)]
+- Configure Renovate [[#1](https://github.com/CrystalNET-org/paperless-ftpd/pull/1)]
+- update renovate config ([3096bc5](https://github.com/CrystalNET-org/paperless-ftpd/commit/3096bc55ddf01133160aadde4f3209e3d590628d))
+- update renovate config ([6621e96](https://github.com/CrystalNET-org/paperless-ftpd/commit/6621e961d6a1d1ef49eab322134948f6025837b2))
+- update renovate config ([f621aac](https://github.com/CrystalNET-org/paperless-ftpd/commit/f621aacf6bb8fa83b6f00d066c8c1d16d77cf2fb))
+- update renovate config ([a3e9fae](https://github.com/CrystalNET-org/paperless-ftpd/commit/a3e9faed33fa79a8298fda798dd50845bdec378c))
+- update renovate config ([38bed29](https://github.com/CrystalNET-org/paperless-ftpd/commit/38bed29900423717457fe4515e2241a92da0071f))
+- renovate debugging ([544eaec](https://github.com/CrystalNET-org/paperless-ftpd/commit/544eaecf4f4edefe3bbd1bc7c0a4572f3d2edd98))
+- fix renovate image used ([06c096b](https://github.com/CrystalNET-org/paperless-ftpd/commit/06c096b0edd27dcc407ff9d2cd61fe4096f51638))
+- fix renovate image used ([efd4120](https://github.com/CrystalNET-org/paperless-ftpd/commit/efd4120d1c6a8014deabf2ece0de029b9738fafd))
+- fix renovate image used ([e4ecd71](https://github.com/CrystalNET-org/paperless-ftpd/commit/e4ecd71844a6bde45dccd4c6130dee34db6f40ae))
+- fix renovate image used ([ed2077b](https://github.com/CrystalNET-org/paperless-ftpd/commit/ed2077b3c32397664fd486f526d409da3033245d))
+- try to use renovate ([605110a](https://github.com/CrystalNET-org/paperless-ftpd/commit/605110a27b652945de14082314da1a5662f28f2f))
+- splitting build breaks the combined multiarch image in harbor ([62eb4ec](https://github.com/CrystalNET-org/paperless-ftpd/commit/62eb4ec13ec6f87abf57734207657d0fee2d5019))
+- split pipeline ([a370187](https://github.com/CrystalNET-org/paperless-ftpd/commit/a370187251e779f8d4a49d7bd84de2d2c0e156bb))
+- use prebuild binaries for paperless_auth plugin ([691ac67](https://github.com/CrystalNET-org/paperless-ftpd/commit/691ac6746d729674e8c8a3de673a5e94029822fb))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Misc
 
+- update args ([1a06c72](https://github.com/CrystalNET-org/paperless-ftpd/commit/1a06c728e6a25e143f101a94b9699c422df96bf2))
+- update buildx ([ac60aba](https://github.com/CrystalNET-org/paperless-ftpd/commit/ac60abade4d60a09f76c6ce09b4166d0896d35bc))
 - move arg ([39ff3a6](https://github.com/CrystalNET-org/paperless-ftpd/commit/39ff3a6dea68b4e1754f8ed13e6ea6e318aabe53))
 - Update renovate/renovate Docker tag to v38 [[#13](https://github.com/CrystalNET-org/paperless-ftpd/pull/13)]
 - Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#12](https://github.com/CrystalNET-org/paperless-ftpd/pull/12)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- add executable flag ([398955b](https://github.com/CrystalNET-org/paperless-ftpd/commit/398955b78b2725da4131f06e26cef809fcd83e72))
 - cleanup debug echo ([29fa75e](https://github.com/CrystalNET-org/paperless-ftpd/commit/29fa75e9d9bcc494d4a78932c6c673140976cd5d))
 - cleanup arch if block, dont build for i386 anymore ([2874602](https://github.com/CrystalNET-org/paperless-ftpd/commit/28746020f3f2b50a7d7f6df40609a2a6594e6b1d))
 - fix arguments supplied to the build stage ([880eb15](https://github.com/CrystalNET-org/paperless-ftpd/commit/880eb15d36912e4c36dbccf32dcdaec03740d25c))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.4](https://github.com/CrystalNET-org/paperless-ftpd/releases/tag/0.2.4) - 2024-02-05
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update renovate/renovate Docker tag to v37.140.10 [[#8](https://github.com/CrystalNET-org/paperless-ftpd/pull/8)]
+- Update renovate/renovate Docker tag to v37.115.0 [[#7](https://github.com/CrystalNET-org/paperless-ftpd/pull/7)]
+
 ## [0.2.3](https://github.com/CrystalNET-org/paperless-ftpd/releases/tag/0.2.3) - 2023-12-22
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Misc
 
+- cleanup debug echo ([29fa75e](https://github.com/CrystalNET-org/paperless-ftpd/commit/29fa75e9d9bcc494d4a78932c6c673140976cd5d))
+- cleanup arch if block, dont build for i386 anymore ([2874602](https://github.com/CrystalNET-org/paperless-ftpd/commit/28746020f3f2b50a7d7f6df40609a2a6594e6b1d))
+- fix arguments supplied to the build stage ([880eb15](https://github.com/CrystalNET-org/paperless-ftpd/commit/880eb15d36912e4c36dbccf32dcdaec03740d25c))
 - update args ([1a06c72](https://github.com/CrystalNET-org/paperless-ftpd/commit/1a06c728e6a25e143f101a94b9699c422df96bf2))
 - update buildx ([ac60aba](https://github.com/CrystalNET-org/paperless-ftpd/commit/ac60abade4d60a09f76c6ce09b4166d0896d35bc))
 - move arg ([39ff3a6](https://github.com/CrystalNET-org/paperless-ftpd/commit/39ff3a6dea68b4e1754f8ed13e6ea6e318aabe53))


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.4` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.4](https://github.com/CrystalNET-org/paperless-ftpd/releases/tag/0.2.4) - 2024-10-28

### Misc

- add executable flag ([398955b](https://github.com/CrystalNET-org/paperless-ftpd/commit/398955b78b2725da4131f06e26cef809fcd83e72))
- cleanup debug echo ([29fa75e](https://github.com/CrystalNET-org/paperless-ftpd/commit/29fa75e9d9bcc494d4a78932c6c673140976cd5d))
- cleanup arch if block, dont build for i386 anymore ([2874602](https://github.com/CrystalNET-org/paperless-ftpd/commit/28746020f3f2b50a7d7f6df40609a2a6594e6b1d))
- fix arguments supplied to the build stage ([880eb15](https://github.com/CrystalNET-org/paperless-ftpd/commit/880eb15d36912e4c36dbccf32dcdaec03740d25c))
- update args ([1a06c72](https://github.com/CrystalNET-org/paperless-ftpd/commit/1a06c728e6a25e143f101a94b9699c422df96bf2))
- update buildx ([ac60aba](https://github.com/CrystalNET-org/paperless-ftpd/commit/ac60abade4d60a09f76c6ce09b4166d0896d35bc))
- move arg ([39ff3a6](https://github.com/CrystalNET-org/paperless-ftpd/commit/39ff3a6dea68b4e1754f8ed13e6ea6e318aabe53))
- Update renovate/renovate Docker tag to v38 [[#13](https://github.com/CrystalNET-org/paperless-ftpd/pull/13)]
- Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#12](https://github.com/CrystalNET-org/paperless-ftpd/pull/12)]
- Update renovate/renovate Docker tag to v37.440.7 [[#11](https://github.com/CrystalNET-org/paperless-ftpd/pull/11)]
- comment default ([5b2524c](https://github.com/CrystalNET-org/paperless-ftpd/commit/5b2524c2e4b96bd88c126478d3037e0553bcce0e))
- update dependencies and fix paperless-auth release location ([c2ce914](https://github.com/CrystalNET-org/paperless-ftpd/commit/c2ce9146c01b9d468e34c03cdd2d346592456f2e))
- update paperless-dbauth plugin to latest version ([a41b6b2](https://github.com/CrystalNET-org/paperless-ftpd/commit/a41b6b2569b91256430b15667946b476e2ba9532))
- Update renovate/renovate Docker tag to v37.140.10 [[#8](https://github.com/CrystalNET-org/paperless-ftpd/pull/8)]
- Update renovate/renovate Docker tag to v37.115.0 [[#7](https://github.com/CrystalNET-org/paperless-ftpd/pull/7)]